### PR TITLE
Fixes for Windows Users

### DIFF
--- a/docker-clean.bat
+++ b/docker-clean.bat
@@ -1,0 +1,1 @@
+docker rm -f $(docker ps -aq)

--- a/psql.bat
+++ b/psql.bat
@@ -1,0 +1,11 @@
+@echo off
+echo "==================     Help for psql   ========================="
+echo "\\dt		: Describe the current database"
+echo "\\t [table]	: Describe a table"
+echo "\\c		: Connect to a database"
+echo "\\h		: help with SQL commands"
+echo "\\?		: help with psql commands"
+echo "\\q		: quit"
+echo "=================================================================="
+@echo on
+docker exec -it postgres psql -U docker -d rtjvm

--- a/spark-cluster/build-images.bat
+++ b/spark-cluster/build-images.bat
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+docker build -t spark-base:latest ./docker/base
+docker build -t spark-master:latest ./docker/spark-master
+docker build -t spark-worker:latest ./docker/spark-worker
+docker build -t spark-submit:latest ./docker/spark-submit

--- a/spark-cluster/docker/spark-master/Dockerfile
+++ b/spark-cluster/docker/spark-master/Dockerfile
@@ -1,11 +1,15 @@
 FROM spark-base:latest
 
+RUN apt-get update && apt-get install -y dos2unix
 COPY start-master.sh /
+RUN dos2unix /start-master.sh && apt-get --purge remove -y dos2unix && rm -rf /var/lib/apt/lists/*
 
 ENV SPARK_MASTER_PORT 7077
 ENV SPARK_MASTER_WEBUI_PORT 8080
 ENV SPARK_MASTER_LOG /spark/logs
 
 EXPOSE 8080 7077 6066
+
+
 
 CMD ["/bin/bash", "/start-master.sh"]

--- a/spark-cluster/docker/spark-submit/Dockerfile
+++ b/spark-cluster/docker/spark-submit/Dockerfile
@@ -1,6 +1,8 @@
 FROM spark-base:latest
 
+RUN apt-get update && apt-get install -y dos2unix
 COPY spark-submit.sh /
+RUN dos2unix /spark-submit.sh && apt-get --purge remove -y dos2unix && rm -rf /var/lib/apt/lists/*
 
 ENV SPARK_MASTER_URL="spark://spark-master:7077"
 ENV SPARK_SUBMIT_ARGS=""

--- a/spark-cluster/docker/spark-worker/Dockerfile
+++ b/spark-cluster/docker/spark-worker/Dockerfile
@@ -1,6 +1,8 @@
 FROM spark-base:latest
 
+RUN apt-get update && apt-get install -y dos2unix
 COPY start-worker.sh /
+RUN dos2unix /start-worker.sh && apt-get --purge remove -y dos2unix && rm -rf /var/lib/apt/lists/*
 
 ENV SPARK_WORKER_WEBUI_PORT 8081
 ENV SPARK_WORKER_LOG /spark/logs


### PR DESCRIPTION
Two small fixes for windows users:

- creates bat file version of the sh scripts
- Docker-compose on windows adds windows line endings on copy, added dos2unix in the image to change them back.  It should be a no op on mac and linux, but someone with a mac/linux will need to test.